### PR TITLE
Don't redundantly specify the default template argument to `BumpPtrAl…

### DIFF
--- a/clang/lib/AST/ByteCode/DynamicAllocator.h
+++ b/clang/lib/AST/ByteCode/DynamicAllocator.h
@@ -97,7 +97,7 @@ public:
 private:
   llvm::DenseMap<const Expr *, AllocationSite> AllocationSites;
 
-  using PoolAllocTy = llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator>;
+  using PoolAllocTy = llvm::BumpPtrAllocator;
   PoolAllocTy DescAllocator;
 
   /// Allocates a new descriptor.


### PR DESCRIPTION
…locatorImpl`